### PR TITLE
Add camera position support

### DIFF
--- a/include/ARSessionImpl.h
+++ b/include/ARSessionImpl.h
@@ -81,6 +81,7 @@ public:
 
     mat4                   mViewMatrix;
     mat4                   mProjectionMatrix;
+    vec3                   mCameraPosition;
     
     float                  mAmbientLightIntensity;
     float                  mAmbientColorTemperature;

--- a/include/CinderARKit.h
+++ b/include/CinderARKit.h
@@ -74,6 +74,10 @@ public:
     */
     const mat4 getProjectionMatrix() const;
     
+    /**  Get the position of the device camera
+     */
+    const vec3 getCameraPosition() const;
+    
 
     //===== Camera Capture =====================================================//
     /**  Set whether to process the colour image from the camera

--- a/src/ARSessionImpl.mm
+++ b/src/ARSessionImpl.mm
@@ -108,6 +108,10 @@ bool SessionImpl::isInterfaceInPortraitOrientation() const
     // Update view matrix
     ciARKitSession->mViewMatrix = toMat4([frame.camera viewMatrixForOrientation:orientation]);
     
+    //  Update Camera position
+    mat4 mtxTransform = toMat4(frame.camera.transform);
+    ciARKitSession->mCameraPosition = vec3(mtxTransform[3]);
+    
     // Update projection matrix
     auto viewBounds = [[UIScreen mainScreen] bounds];
     CGSize viewportSize = viewBounds.size;

--- a/src/CinderARKit.cpp
+++ b/src/CinderARKit.cpp
@@ -27,6 +27,7 @@ const std::vector<ImageAnchor>& Session::getImageAnchors() const    { return mSe
 void Session::setRGBCaptureEnabled( bool captureEnabled )           { mSessionImpl.mRGBCaptureEnabled = captureEnabled; }
 const mat4 Session::getViewMatrix() const                           { return mSessionImpl.mViewMatrix; }
 const mat4 Session::getProjectionMatrix() const                     { return mSessionImpl.mProjectionMatrix; }
+const vec3 Session::getCameraPosition() const                       { return mSessionImpl.mCameraPosition; }
 
 std::shared_ptr<Anchor> Session::findAnchorWithID( AnchorID anchorID ) const
 {


### PR DESCRIPTION
Even though we can extract the camera position from View Matrix, it will still useful if we can have a method to get the camera position easily. 

I am not really sure about the way I'm getting the vec3 from mat4 here : 
```
mat4 mtxTransform = toMat4(frame.camera.transform);
ciARKitSession->mCameraPosition = vec3(mtxTransform[3]);
```

Please feel free to correct this if it's a bad way to implement it.